### PR TITLE
Add support for BME280 sensor

### DIFF
--- a/bmp280/bmp280.go
+++ b/bmp280/bmp280.go
@@ -24,6 +24,7 @@ const (
 	ChipID1 = 0x56
 	ChipID2 = 0x57
 	ChipID3 = 0x58
+	ChipID4 = 0x60
 	// Power Mode Definitions
 	SleepMode     = 0x00
 	ForcedMode    = 0x01
@@ -135,7 +136,7 @@ func NewBMP280(i2cbus *embd.I2CBus, address, powerMode, standby, filter, tempRes
 			err = fmt.Errorf("BMP280: couldn't find chip at address %x: %s", address, errv)
 			continue
 		}
-		if v[0] == ChipID1 || v[0] == ChipID2 || v[0] == ChipID3 {
+		if v[0] == ChipID1 || v[0] == ChipID2 || v[0] == ChipID3 || v[0] == ChipID4 {
 			err = nil
 			break
 		}


### PR DESCRIPTION
From the BME280 datasheet(Section 5.2), BME280 is register compatible with BMP280, and the pressure & temperature control and readout is identical, with a few exceptions that are considered below.

1. BME280 has a ChipID of 0x60 (Code has been updated to accept this ChipID)

2. t_sb has a different map. The current code uses a value of t_sb of  StandbyTime63ms (0x01) which is the same across both sensors

3. Pressure resolution might differ on filter settings for BME280

-- BMP280 resolution only depends on osrs_p ,which is set to Oversamp16x (0x05) corresponding to an oversampling of 16x. This sets the pressure resolution to 20 bits.

-- BME280 resolution depends if the filter is on or off. In the current code, filter is set to FilterCoeff16(0x04), which corresponds to a filter coefficient of 16. This sets the pressure resolution to 20 bits.

Pressure resolution is set to 20 bits on both sensors

4. Temperature resolution

Temperature resolution is set to 20 bits on both sensors following a similar reasoning as point 3 above.


Tested on BME280 module(GY-BM) wired directly to raspberry pi with the following pins and using  I2C address of 0x76.
- Pin 1 : 3.3v
- Pin 3 : SDA
- Pin 5 : SCL
- Pin 9 : GND

NO IMU module was connected.